### PR TITLE
hideOnScrollChanged output + exportAs + detectHideOnScroll directive

### DIFF
--- a/projects/ngx-hide-on-scroll/src/lib/ngx-detect-hide-on-scroll.directive.ts
+++ b/projects/ngx-hide-on-scroll/src/lib/ngx-detect-hide-on-scroll.directive.ts
@@ -1,0 +1,20 @@
+import { AfterContentInit, Directive, OnDestroy } from '@angular/core';
+import { NgxHideOnScrollService } from './ngx-hide-on-scroll.service';
+
+
+/**
+ * Use this on scrollable elements to notify [ngxHideOnScroll] on render updates (e.g *ngIfs)
+ */
+@Directive({ selector: '[ngxDetectHideOnScroll]' })
+export class NgxDetectHideOnScrollDirective implements AfterContentInit, OnDestroy {
+
+  constructor(private s: NgxHideOnScrollService) { }
+
+  ngAfterContentInit() {
+    this.s.scrollingElementsDetected$.next();
+  }
+  ngOnDestroy() {
+    this.s.scrollingElementsDetected$.next();
+  }
+
+}

--- a/projects/ngx-hide-on-scroll/src/lib/ngx-detect-hide-on-scroll.directive.ts
+++ b/projects/ngx-hide-on-scroll/src/lib/ngx-detect-hide-on-scroll.directive.ts
@@ -1,20 +1,18 @@
 import { AfterContentInit, Directive, OnDestroy } from '@angular/core';
 import { NgxHideOnScrollService } from './ngx-hide-on-scroll.service';
 
-
 /**
  * Use this on scrollable elements to notify [ngxHideOnScroll] on render updates (e.g *ngIfs)
  */
 @Directive({ selector: '[ngxDetectHideOnScroll]' })
 export class NgxDetectHideOnScrollDirective implements AfterContentInit, OnDestroy {
-
-  constructor(private s: NgxHideOnScrollService) { }
+  constructor(private s: NgxHideOnScrollService) {}
 
   ngAfterContentInit() {
-    this.s.scrollingElementsDetected$.next();
+    // wait a tick to let initted element render
+    setTimeout(() => this.s.scrollingElementsDetected$.next());
   }
   ngOnDestroy() {
     this.s.scrollingElementsDetected$.next();
   }
-
 }

--- a/projects/ngx-hide-on-scroll/src/lib/ngx-hide-on-scroll.directive.ts
+++ b/projects/ngx-hide-on-scroll/src/lib/ngx-hide-on-scroll.directive.ts
@@ -30,17 +30,17 @@ export class NgxHideOnScrollDirective implements AfterViewInit, OnDestroy {
   /**
    * The CSS property used to hide/show the element.
    */
-  @Input() propertyUsedToHide: 'top' | 'bottom' | 'height' = 'top';
+  @Input() propertyUsedToHide: 'top' | 'bottom' | 'height' | 'transform' = 'transform';
 
   /**
    * The value of `propertyUsedToHide` when the element is hidden.
    */
-  @Input() valueWhenHidden: string = '-100px';
+  @Input() valueWhenHidden: string = 'translateY(-100%)';
 
   /**
    * The value of `propertyUsedToHide` when the element is shown.
    */
-  @Input() valueWhenShown: string = '0px';
+  @Input() valueWhenShown: string = 'translateY(0)';
 
   /**
    * The selector of the element you want to listen the scroll event, in case it is not the default browser scrolling element (`document.scrollingElement` or `document.documentElement`). For example [` .mat-sidenav-content`]( https://stackoverflow.com/a/52931772/12954396) if you are using [Angular Material Sidenav]( https://material.angular.io/components/sidenav)
@@ -125,18 +125,25 @@ export class NgxHideOnScrollDirective implements AfterViewInit, OnDestroy {
   private reset(destroyed?: boolean) {
     this.unsubscribeNotifier.next();
     this.unsubscribeNotifier.complete();
-    if(destroyed) {
+    if (destroyed) {
       this.destroyedNotifier.next();
       this.destroyedNotifier.complete();
     }
   }
 
+  private _isHidden: boolean = false;
+  get isHidden() {
+    return this._isHidden;
+  }
+
   hideElement() {
     this.elementRef.nativeElement.style[this.propertyUsedToHide] = this.valueWhenHidden;
+    this._isHidden = true;
   }
 
   showElement() {
     this.elementRef.nativeElement.style[this.propertyUsedToHide] = this.valueWhenShown;
+    this._isHidden = false;
   }
 
   private getDefaultScrollingElement() {

--- a/projects/ngx-hide-on-scroll/src/lib/ngx-hide-on-scroll.module.ts
+++ b/projects/ngx-hide-on-scroll/src/lib/ngx-hide-on-scroll.module.ts
@@ -1,10 +1,13 @@
 import { NgModule } from '@angular/core';
+import { NgxDetectHideOnScrollDirective } from './ngx-detect-hide-on-scroll.directive';
 import { NgxHideOnScrollDirective } from './ngx-hide-on-scroll.directive';
+import { NgxHideOnScrollService } from './ngx-hide-on-scroll.service';
 
 
 @NgModule({
-  declarations: [NgxHideOnScrollDirective],
+  declarations: [NgxHideOnScrollDirective, NgxDetectHideOnScrollDirective],
   imports: [],
-  exports: [NgxHideOnScrollDirective]
+  providers: [NgxHideOnScrollService],
+  exports: [NgxHideOnScrollDirective, NgxDetectHideOnScrollDirective]
 })
 export class NgxHideOnScrollModule { }

--- a/projects/ngx-hide-on-scroll/src/lib/ngx-hide-on-scroll.module.ts
+++ b/projects/ngx-hide-on-scroll/src/lib/ngx-hide-on-scroll.module.ts
@@ -7,7 +7,6 @@ import { NgxHideOnScrollService } from './ngx-hide-on-scroll.service';
 @NgModule({
   declarations: [NgxHideOnScrollDirective, NgxDetectHideOnScrollDirective],
   imports: [],
-  providers: [NgxHideOnScrollService],
   exports: [NgxHideOnScrollDirective, NgxDetectHideOnScrollDirective]
 })
 export class NgxHideOnScrollModule { }

--- a/projects/ngx-hide-on-scroll/src/lib/ngx-hide-on-scroll.service.ts
+++ b/projects/ngx-hide-on-scroll/src/lib/ngx-hide-on-scroll.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+
+@Injectable({providedIn: 'root'})
+export class NgxHideOnScrollService {
+  readonly scrollingElementsDetected$ = new Subject<void>();
+}

--- a/projects/ngx-hide-on-scroll/src/public-api.ts
+++ b/projects/ngx-hide-on-scroll/src/public-api.ts
@@ -4,3 +4,4 @@
 
 export * from './lib/ngx-hide-on-scroll.module';
 export * from './lib/ngx-hide-on-scroll.directive';
+export * from './lib/ngx-detect-hide-on-scroll.directive';


### PR DESCRIPTION
Various improvements to match my needs:

1. Needed a way initialize the directive on demand.
    Solution: Move initialize code into public `init()` method and use `exportAs` to optionally call it when needed.
    ```html
    <div ngxHideOnScroll #hos="ngxHideOnScroll"></div>
    <my-comp (something)="hos.init()"></my-comp>
    ```

2. My scrolling element was in separate module than the hide element, and was not always loaded directly. Needed a way to detect when scrolling element was available, so added `[detectHideOnScroll]` directive, which uses a service to track all detections. 
   When used, all `[ngxHideOnScroll]` gets re-initialized when new scrolling elements is detected.
   ```html
   <!-- module A -->
   <div ngxHideOnScroll scrollingElementSelector=".my-scroller"></div>

   <!-- module B -->
   <div *ngIf="notAlwaysTrue" ngxDetectHideOnScroll class="my-scroller"></div>
   ```


3. Wanted to use `transform: translateY()` as hide/show property, so added to the list and actually set `translateY(-100%)` as default. Makes a better default case than `top: -100px` :)

4. Instead of using single style property to toggle hide/show, I wanted to set optional class to the element. Because we now exports the directive, I only needed to add a `isHidden` property to the directive.
   ```html
   <div ngxHideOnScroll #hos="ngxHideOnScroll" [class.fly-away]="hos.isHidden"></div>
   ```
   
5. Later, setting custom class to element by `isHidden` prop wasn't enough - I needed to make certain tweaks when hide/show changed. So added `hideOnScrollChanged` output with new `IHideOnScrollChangedEvent` interface as argument:
   ```html
   <div ngxHideOnScroll (hideOnScrollChanged)="handleHideOnScroll($event)"></div>
   ```